### PR TITLE
Add architecture decision records

### DIFF
--- a/docs/adr/0-template_adr.md
+++ b/docs/adr/0-template_adr.md
@@ -1,0 +1,23 @@
+# ADR template
+
+Template based on [Documenting architecture decisions - Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions), [Markdown version](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md) from Joel Parker Henderson.
+
+In each ADR file, write these sections:
+
+# Title
+
+## Status
+
+What is the status, such as: proposed, accepted, rejected, deprecated, superseded, etc.?
+
+## Context
+
+What is the issue that we are seeing that is motivating this decision or change?
+
+## Decision
+
+What is the change that we are proposing and/or doing?
+
+## Consequences
+
+What becomes easier or more difficult to do because of this change?

--- a/docs/adr/0-template_adr.md
+++ b/docs/adr/0-template_adr.md
@@ -1,14 +1,14 @@
 # ADR template
 
-Template based on [Documenting architecture decisions - Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions), [Markdown version](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md) from Joel Parker Henderson.
+Template based on [Documenting architecture decisions](https://web.archive.org/web/20200129074448/http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions) by Michael Nygard. [Markdown temaplte](https://github.com/joelparkerhenderson/architecture_decision_record/blob/master/adr_template_by_michael_nygard.md) by Joel Parker Henderson.
 
-In each ADR file, write these sections:
+In each ADR is described into a single file, following the file name template: ```#-<descriptive_title>.md```, e.g.: ```1-include_team_topologies_interaction.md```). The ADR should have the following sections:
 
 # Title
 
 ## Status
 
-What is the status, such as: proposed, accepted, rejected, deprecated, superseded, etc.?
+What is the status, such as: proposed, accepted, rejected, deprecated, superseded, etc.
 
 ## Context
 


### PR DESCRIPTION
May be interesting to have "decision records" (like in ADR) for the "significant decisions" taken on the changes on the template (for example, why are we adding a certain element or removing other... this is very helpful to track and understand the evolution of the template/model and the motivations for changes). This may actually be a good addition to all the templates under ddd-crew.